### PR TITLE
add protocol:slashauth

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -87,7 +87,8 @@ class SlashAuthServer {
   formatUrl (token) {
     return SlashtagsURL.format(this.keypair.publicKey, {
       path: `/${this.rpc.version}/${this.rpc.route}`,
-      query: `token=${token}&relay=http://${this.rpc.host}:${this.rpc.port}`
+      query: `token=${token}&relay=http://${this.rpc.host}:${this.rpc.port}`,
+      protocol: 'slashauth:'
     })
   }
 


### PR DESCRIPTION
Currently when I generate the url I get something like: "slash:komttxichdri7urdbo5bdqeetk4qifzy8edejjrr6tmjmsgjpdio/v0.1/auth? token=vr5b2okrr5i&relay=http://localhost:8000"

I would need something like: "slashauth:komttxichdri7urdbo5bdqeetk4qifzy8edejjrr6tmjmsgjpdio/v0.1/auth? token=vr5b2okrr5i&relay=http://localhost:8000"

For this reason I added `protocol: 'slashauth:'`