### PR TITLE
update port

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -63,7 +63,7 @@ class SlashAuthServer {
     this.keypair = opts.keypair
 
     this.rpc = {
-      port: opts.port || 8000,
+      port: opts.port === null ? "" : opts.port || 8000,
       host: opts.host || 'localhost',
       route: opts.route || 'auth',
       version: opts.version || 'v0.1',


### PR DESCRIPTION
Currently it is required that there is a port, but if I want to insert only the webrelay url without port I cannot do it and I believe that in the future when we would like to insert only "webrelay.slashtags.to" for example we would need this modification